### PR TITLE
🔍 Scrutineer: Remove unimplemented upgrade command

### DIFF
--- a/src/fvc/tools/df/cli.py
+++ b/src/fvc/tools/df/cli.py
@@ -154,24 +154,6 @@ def export_command(params, output_file, **kwargs):
     core.export(params)
 
 
-@df.command(help='Upgrade a FVC file to the latest schema (volatile code)')
-@click.argument('infile', type=click.Path(exists=True, path_type=Path), required=True)
-@click.pass_obj
-def upgrade(params, infile):
-    params['input_path'] = infile
-    params['output_path'] = infile.with_suffix('.fvc')
-
-    with Progress(transient=True) as progress:
-        read_task = progress.add_task('Reading...', total=infile.stat().st_size)
-        write_task = progress.add_task('Writing...', total=infile.stat().st_size)
-
-        core.upgrade(
-            params,
-            lambda s: progress.update(read_task, advance=s),
-            lambda s: progress.update(write_task, advance=s),
-        )
-
-
 @df.command(help='Correlate several flightlogs')
 @click.pass_obj
 @click.argument(

--- a/src/fvc/tools/df/core.py
+++ b/src/fvc/tools/df/core.py
@@ -132,13 +132,3 @@ def export(params: DFParams):
     lg.info(f'Export complete, output written to {real_output}')
 
 
-def upgrade(params: DFParams):
-    """Parameters:
-    - input_path: input file path
-    - output_path: output file path
-    - x_format: external format
-    """
-
-    # input_path = params['input_path']
-    # output_path = params['output_path']
-    raise NotImplementedError('Upgrade is not implemented')


### PR DESCRIPTION
The Bullshit: The `fvc df upgrade` command was exposed in the CLI but wired to a stub function (`core.upgrade`) that only threw a `NotImplementedError`. Moreover, the CLI command passed three arguments to the core function which only accepted one, meaning it was doubly broken.

The Fix: Removed the dead `upgrade` command entirely from the CLI and removed the unimplemented logic from `fvc.tools.df.core`.

Result: Reduced cognitive load by removing a broken and useless command, deleting 28 lines of dead code.

---
*PR created automatically by Jules for task [2281055269096899636](https://jules.google.com/task/2281055269096899636) started by @scartill*