### PR TITLE
🔍 Scrutineer: Remove unnecessary inheritance in FvcDataset

### DIFF
--- a/src/fvc/tools/df/utils.py
+++ b/src/fvc/tools/df/utils.py
@@ -102,7 +102,7 @@ def input_path(params: benedict) -> Path:
     return path
 
 
-class FvcDataset(JsonlinesIO):
+class FvcDataset:
     @staticmethod
     def read(filepath: Path) -> 'FvcDataset':
         with JsonlinesIO(filepath, 'r') as io:


### PR DESCRIPTION
The Bullshit: `FvcDataset` was needlessly inheriting from `JsonlinesIO`. It never called `super().__init__()` and its `read` static method instantiated a new `JsonlinesIO` instance internally using a context manager. This was pure cargo-cult inheritance that added unnecessary cognitive load.

The Fix: Removed `JsonlinesIO` from the class signature of `FvcDataset`.

Result: Reduced architectural clutter and simplified a core utility class, keeping changes under 40 lines.

---
*PR created automatically by Jules for task [17934423793774496698](https://jules.google.com/task/17934423793774496698) started by @scartill*