### PR TITLE
🔍 Scrutineer: Remove unnecessary generate_features wrapper

### DIFF
--- a/src/fvc/tools/df/xformats/geojson.py
+++ b/src/fvc/tools/df/xformats/geojson.py
@@ -74,13 +74,6 @@ def generate_line(params, record, curr_pos):
     return line
 
 
-def generate_features(params, record, curr_pos):
-    return [
-        generate_point(params, record),
-        generate_line(params, record, curr_pos),
-    ]
-
-
 def generate_geojson(features):
     collection = {'type': 'FeatureCollection', 'features': features}
 
@@ -126,7 +119,12 @@ def export_from_fvc(params, output_path: Path | None):
 
         for record in io.iterate():
             try:
-                features.extend(generate_features(params, record, curr_pos))
+                features.extend(
+                    [
+                        generate_point(params, record),
+                        generate_line(params, record, curr_pos),
+                    ]
+                )
             except UserWarning as e:
                 lg.warning(f'Unable to process record: {e}')
                 continue

--- a/src/fvc/tools/df/xformats/kml/__init__.py
+++ b/src/fvc/tools/df/xformats/kml/__init__.py
@@ -70,11 +70,6 @@ def generate_line(params, record, curr_pos, kml):
     curr_pos['alt'] = loc.get('alt')
 
 
-def generate_features(params, record, curr_pos, kml):
-    generate_point(params, record, kml)
-    generate_line(params, record, curr_pos, kml)
-
-
 def export_from_fvc(params, output_path: Path | None):
     input_path = params['input'].fetch()
 
@@ -111,7 +106,8 @@ def export_from_fvc(params, output_path: Path | None):
 
         for record in io.iterate():
             try:
-                generate_features(params, record, curr_pos, kml)
+                generate_point(params, record, kml)
+                generate_line(params, record, curr_pos, kml)
             except UserWarning as e:
                 lg.warning(f'Unable to process record: {e}')
                 continue


### PR DESCRIPTION
The Bullshit: The generate_features function in both KML and GeoJSON exporters acts as a simple pass-through wrapper for generating points and lines, adding unnecessary indirection.

The Fix: Inlined the point and line generation directly into the export loop and deleted the generate_features functions.

Result: Removed redundant wrapper functions and flattened the logic.

---
*PR created automatically by Jules for task [12248774577724204675](https://jules.google.com/task/12248774577724204675) started by @scartill*