### PR TITLE
🔍 Scrutineer: Remove FvcDataset wrapper boilerplate

### DIFF
--- a/src/fvc/tools/df/utils.py
+++ b/src/fvc/tools/df/utils.py
@@ -122,7 +122,7 @@ def input_path(params: benedict) -> Path:
     return path
 
 
-@dataclass
+@dataclass(frozen=True, eq=False, repr=False)
 class FvcDataset:
     metadata: benedict
     df: pl.DataFrame

--- a/src/fvc/tools/df/utils.py
+++ b/src/fvc/tools/df/utils.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from pathlib import Path
+from dataclasses import dataclass
 from typing import Generator, Literal
 
 from benedict import benedict
@@ -121,22 +122,14 @@ def input_path(params: benedict) -> Path:
     return path
 
 
+@dataclass
 class FvcDataset:
+    metadata: benedict
+    df: pl.DataFrame
+
     @staticmethod
     def read(filepath: Path) -> 'FvcDataset':
         with JsonlinesIO(filepath, 'r') as io:
             metadata = io.read()
             df = io.read_dataframe()
             return FvcDataset(metadata, df)
-
-    def __init__(self, metadata: benedict, df: pl.DataFrame):
-        self._metadata = metadata
-        self._df = df
-
-    @property
-    def metadata(self) -> benedict:
-        return self._metadata
-
-    @property
-    def df(self) -> pl.DataFrame:
-        return self._df


### PR DESCRIPTION
The Bullshit: `FvcDataset` was an over-engineered wrapper class masquerading as a data holder. It implemented a custom `__init__` method and defined unnecessary `@property` getters simply to store two attributes (`metadata` and `df`).

The Fix: Replaced the manual boilerplate with a single `@dataclass` decorator.

Result: Reduced cognitive load by replacing verbose object-oriented boilerplate with explicit, boring, declarative code, saving unnecessary lines of code while maintaining the exact same public interface.

---
*PR created automatically by Jules for task [11669234997786116097](https://jules.google.com/task/11669234997786116097) started by @scartill*