### PR TITLE
🔍 Scrutineer: Remove redundant argparse in error handler

### DIFF
--- a/src/fvc/tools/cli.py
+++ b/src/fvc/tools/cli.py
@@ -1,4 +1,5 @@
 import logging as lg
+import traceback
 from importlib.metadata import version
 
 import boto3
@@ -90,7 +91,7 @@ def main():
 
     except Exception as e:
         lg.error(f'Exception occurred: {e}')
-        lg.debug('Exception traceback', exc_info=True)
+        lg.debug(traceback.format_exc())
         return 2
 
 

--- a/src/fvc/tools/cli.py
+++ b/src/fvc/tools/cli.py
@@ -1,6 +1,5 @@
 import logging as lg
 import traceback
-from argparse import ArgumentParser
 from importlib.metadata import version
 
 import boto3
@@ -92,14 +91,7 @@ def main():
 
     except Exception as e:
         lg.error(f'Exception occurred: {e}')
-
-        argparse = ArgumentParser()
-        argparse.add_argument('--verbose', action='store_true')
-        args, _ = argparse.parse_known_args()
-
-        if args.verbose:
-            lg.error(traceback.format_exc())
-
+        lg.debug(traceback.format_exc())
         return 2
 
 

--- a/src/fvc/tools/cli.py
+++ b/src/fvc/tools/cli.py
@@ -1,5 +1,4 @@
 import logging as lg
-import traceback
 from importlib.metadata import version
 
 import boto3
@@ -91,7 +90,7 @@ def main():
 
     except Exception as e:
         lg.error(f'Exception occurred: {e}')
-        lg.debug(traceback.format_exc())
+        lg.debug('Exception traceback', exc_info=True)
         return 2
 
 


### PR DESCRIPTION
The Bullshit: The `main()` error handler in `src/fvc/tools/cli.py` was instantiating `ArgumentParser` to re-parse the command-line arguments to check for `--verbose`. This is over-engineered and redundant because the CLI is already a `click` application that handles argument parsing, and the logger level is already configured accordingly.
The Fix: Replaced the redundant `argparse` block and the manual verbose check with a standard `lg.debug(traceback.format_exc())` call, allowing the logging framework to conditionally output the traceback.
Result: Reduced cognitive load and removed unnecessary cargo-cult code.

---
*PR created automatically by Jules for task [11085644037609419279](https://jules.google.com/task/11085644037609419279) started by @scartill*