### PR TITLE
🔍 Scrutineer: Remove unused merge_callback from correlate

### DIFF
--- a/src/fvc/tools/df/cli.py
+++ b/src/fvc/tools/df/cli.py
@@ -166,13 +166,10 @@ def correlate_command(params, infiles: tuple[Path, ...]):
     with Progress() as progress:
         check_tasks = [progress.add_task(f'Checking {infile}...', total=infile.stat().st_size) for infile in infiles]
 
-        merge_task = progress.add_task('Merging...', total=None)
-
         correlate(
             params,
             infiles,
             [lambda s: progress.update(check_tasks[i], advance=s) for i in range(len(check_tasks))],
-            lambda s: progress.update(merge_task, advance=s),
         )
 
 

--- a/src/fvc/tools/df/correlate.py
+++ b/src/fvc/tools/df/correlate.py
@@ -9,7 +9,6 @@ def correlate(
     params: dict[str, Any],
     infiles: tuple[Path, ...],
     check_callbacks: list[Callable[[int], None]],
-    merge_callback: Callable[[int], None],
 ):
     with ThreadPoolExecutor() as executor:
         futures = [executor.submit(_ensure_sorting, infile, check_callbacks[i]) for i, infile in enumerate(infiles)]


### PR DESCRIPTION
The Bullshit: The `correlate` function in `correlate.py` accepted a `merge_callback` argument that was never used inside the function body. In `cli.py`, this forced the creation of an entirely redundant `rich` progress task (`merge_task`) and a dummy lambda function just to satisfy the dead parameter.

The Fix: Removed `merge_callback` from the `correlate` function signature and deleted the unused `merge_task` logic in `cli.py`.

Result: Reduced cognitive load, removed unnecessary progress bar initialization, and eliminated 3 lines of dead code.

---
*PR created automatically by Jules for task [16537228214320876571](https://jules.google.com/task/16537228214320876571) started by @scartill*