### PR TITLE
🔍 Scrutineer: Remove redundant click option wrapper

### DIFF
--- a/src/fvc/tools/df/metadata.py
+++ b/src/fvc/tools/df/metadata.py
@@ -1,4 +1,3 @@
-from functools import wraps
 from pathlib import Path
 
 import click
@@ -8,26 +7,22 @@ from fvc.tools.utils import JSON
 
 
 def metadata_args(command_func):
-    @click.option(
-        '--attach-polar-sensor',
-        help='Attach polar sensor information to metadata for this file',
-        is_flag=True,
-    )
-    @click.option(
-        '--polar-sensor-source',
-        help='Add polar sensor information to metadata for this file',
-        type=click.Path(exists=True, path_type=Path),
-    )
-    @click.option(
+    command_func = click.option(
         '--polar-sensor-format',
         help='Format for polar sensor information',
         type=click.Choice(['nmea']),
-    )
-    @wraps(command_func)
-    def wrapper(*args, **kwargs):
-        command_func(*args, **kwargs)
-
-    return wrapper
+    )(command_func)
+    command_func = click.option(
+        '--polar-sensor-source',
+        help='Add polar sensor information to metadata for this file',
+        type=click.Path(exists=True, path_type=Path),
+    )(command_func)
+    command_func = click.option(
+        '--attach-polar-sensor',
+        help='Attach polar sensor information to metadata for this file',
+        is_flag=True,
+    )(command_func)
+    return command_func
 
 
 def create_metadata(origin, params) -> JSON:


### PR DESCRIPTION
The Bullshit: The `metadata_args` decorator in `src/fvc/tools/df/metadata.py` used an unnecessary inner `wrapper` function with `@wraps` simply to apply Click options. Click decorators inherently wrap the function and return it, meaning the inner wrapper just added a useless layer of indirection (cargo-culting) and swallowed potential return values.

The Fix: Removed the inner wrapper and the `functools.wraps` import. Applied the `click.option` decorators directly to the `command_func` parameter and returned it.

Result: Reduced cognitive load by eliminating an unnecessary abstraction layer, making the code more idiomatic and "boring". Reduced by ~7 lines of code.

---
*PR created automatically by Jules for task [15400263439823272823](https://jules.google.com/task/15400263439823272823) started by @scartill*