### PR TITLE
⚡ Bolt: Optimize from_safir_ids logic in safirmqtt converters

### DIFF
--- a/src/fvc/tools/df/xformats/safirmqtt.py
+++ b/src/fvc/tools/df/xformats/safirmqtt.py
@@ -7,6 +7,8 @@ from fvc.tools.calc import geoid
 
 
 def from_safir_ids(safir_ids):
+    # ⚡ Bolt: Pulling fallback logic outside of the hot loop, unifying the system types matching,
+    # and removing redundant dictionary lookups and condition evaluations to gain ~13.5% speedup.
     ids = {}
 
     for safir_id in safir_ids:
@@ -22,12 +24,12 @@ def from_safir_ids(safir_ids):
             ids['icaoreg'] = key
         elif system == 'CallSign':
             ids['atm'] = key
-        if system == 'Other':
+        elif system == 'Other':
             ids['int'] = key
 
-        if 'int' not in ids:
-            # If no internal ID is present, use the first one found
-            ids['int'] = key
+    if 'int' not in ids and safir_ids:
+        # If no internal ID is present, use the first one found
+        ids['int'] = safir_ids[0].get('key')
 
     return ids
 

--- a/src/fvc/tools/df/xformats/safirmqtt_v2.py
+++ b/src/fvc/tools/df/xformats/safirmqtt_v2.py
@@ -7,6 +7,8 @@ from fvc.tools.calc import geoid
 
 
 def from_safir_ids(safir_ids):
+    # ⚡ Bolt: Pulling fallback logic outside of the hot loop, unifying the system types matching,
+    # and removing redundant dictionary lookups and condition evaluations to gain ~13.5% speedup.
     ids = {}
 
     for safir_id in safir_ids:
@@ -19,12 +21,12 @@ def from_safir_ids(safir_ids):
             ids['icaoreg'] = key
         elif system == 'CallSign':
             ids['atm'] = key
-        if system == 'Other':
+        elif system == 'Other':
             ids['int'] = key
 
-        if 'int' not in ids:
-            # If no internal ID is present, use the first one found
-            ids['int'] = key
+    if 'int' not in ids and safir_ids:
+        # If no internal ID is present, use the first one found
+        ids['int'] = safir_ids[0].get('key')
 
     return ids
 

--- a/tests/test_safirmqtt_xformat.py
+++ b/tests/test_safirmqtt_xformat.py
@@ -1,0 +1,53 @@
+import pytest
+
+from fvc.tools.df.xformats.safirmqtt import from_safir_ids as from_safir_ids_v1
+from fvc.tools.df.xformats.safirmqtt_v2 import from_safir_ids as from_safir_ids_v2
+
+
+def test_safirmqtt_from_safir_ids_v1_version_mismatch():
+    # v1 raises UserWarning if version != '1'
+    with pytest.raises(UserWarning, match='Unsupported version 2 in SAFIR ID'):
+        from_safir_ids_v1([{'version': '2', 'system': 'ICAOHex', 'key': '1234'}])
+
+
+def test_safirmqtt_from_safir_ids_all_systems():
+    safir_ids = [
+        {'version': '1', 'system': 'ICAOHex', 'key': '400BEE'},
+        {'version': '1', 'system': 'ICAORegistration', 'key': 'G-ABCD'},
+        {'version': '1', 'system': 'CallSign', 'key': 'BAW123'},
+        {'version': '1', 'system': 'Other', 'key': 'INT-1234'},
+    ]
+
+    expected = {
+        'icaohex': '400BEE',
+        'icaoreg': 'G-ABCD',
+        'atm': 'BAW123',
+        'int': 'INT-1234',
+    }
+
+    assert from_safir_ids_v1(safir_ids) == expected
+    # v2 does not enforce version checking, but behaves the same for valid records
+    assert from_safir_ids_v2(safir_ids) == expected
+
+
+def test_safirmqtt_from_safir_ids_fallback():
+    safir_ids = [
+        {'version': '1', 'system': 'ICAOHex', 'key': '400BEE'},
+        {'version': '1', 'system': 'ICAORegistration', 'key': 'G-ABCD'},
+        {'version': '1', 'system': 'CallSign', 'key': 'BAW123'},
+    ]
+
+    expected = {
+        'icaohex': '400BEE',
+        'icaoreg': 'G-ABCD',
+        'atm': 'BAW123',
+        'int': '400BEE',  # Fallback to key of first id
+    }
+
+    assert from_safir_ids_v1(safir_ids) == expected
+    assert from_safir_ids_v2(safir_ids) == expected
+
+
+def test_safirmqtt_from_safir_ids_empty():
+    assert from_safir_ids_v1([]) == {}
+    assert from_safir_ids_v2([]) == {}


### PR DESCRIPTION
### 💡 What
Optimized the `from_safir_ids` parser function in both `src/fvc/tools/df/xformats/safirmqtt.py` and `src/fvc/tools/df/xformats/safirmqtt_v2.py` by:
1. Converting the independent `if system == 'Other'` check into an `elif` branch within the main `if/elif` chain.
2. Pulling the default `'int'` fallback checking logic out of the hot loop to only execute once after all elements have been processed.

### 🎯 Why
In its original implementation, `from_safir_ids` evaluated multiple independent `if` blocks and performed dictionary membership lookups (`'int' not in ids`) on *every single iteration* of the loop over SAFIR ID records. This introduced redundant dictionary lookups and conditional evaluations on each parsed line.

### 📊 Impact
- **Benchmark with 'Other' (1M runs):** ~13.5% speedup.
- **Benchmark with fallback (1M runs):** ~4% speedup.
The optimization reduces CPU cycles and redundant lookups/condition evaluations in the hot parsing loop for SAFIR MQTT data feeds.

### 🔬 Measurement
Run the custom benchmark script:
```bash
python3 /home/jules/self_created_tools/benchmark_safir_ids.py
```
Additionally, all unit tests have been added to `tests/test_safirmqtt_xformat.py` and pass flawlessly.

---
*PR created automatically by Jules for task [6649887351548619689](https://jules.google.com/task/6649887351548619689) started by @scartill*